### PR TITLE
update testing NB to work with both VACs

### DIFF
--- a/vac-testing/zall_pix_fixes_PostTests.ipynb
+++ b/vac-testing/zall_pix_fixes_PostTests.ipynb
@@ -5,7 +5,7 @@
    "id": "ec9c4953-55d6-42d5-9da3-a09b1c1b6338",
    "metadata": {},
    "source": [
-    "# Test the fixed zall-pix VAC after creation\n",
+    "# Test the zpix (or ztile) VAC after creation\n",
     "Stephanie Juneau (NOIRLab)\n",
     "\n",
     "\n",
@@ -19,8 +19,16 @@
     "- Document a few remaining issues/features for future action\n",
     "\n",
     "### Redshift catalogs for EDR (SPECPROD = 'fuji'):\n",
-    "- Original: `zall-pix-fuji.fits`\n",
-    "- VAC: `zall-pix-edr-vac.fits`\n",
+    "- Original redshift catalogs: \n",
+    "    - `zall-pix-fuji.fits`\n",
+    "    - `zall-tilecumulative-fuji.fits`\n",
+    "- VAC:\n",
+    "    - `zall-pix-edr-vac.fits`\n",
+    "    - `zall-tilecumulative-edr-vac.fits`\n",
+    "    \n",
+    "### Note\n",
+    "\n",
+    "There are two cells to set up (1) the choice of VAC to test (`'healpix'` for zpix or `'cumulative'` for ztile), and (2) the JupyterLab platform being used (Astro Data Lab or NERSC).\n",
     "\n",
     "### DESI Kernel Version\n",
     "\n",
@@ -55,6 +63,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a7de5b2a-46b4-4549-a693-eb800f3e6e22",
+   "metadata": {},
+   "source": [
+    "## Initial Setup (NERSC or Astro Data Lab?)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "88b2290a-3da7-4e11-ac8a-077072155420",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zcat_type = 'healpix'\n",
+    "#zcat_type = 'cumulative'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "aed96242-e616-48a2-aed1-ff5fd53e1c74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "platform = 'datalab'\n",
+    "#platform = 'nersc'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f24864a2-705b-432d-9933-453ac1374881",
    "metadata": {},
    "source": [
@@ -63,36 +101,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
+   "id": "f38c579e-9784-4e60-bd0c-1c948004bfcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specprod = \"fuji\"    # Internal name for the EDR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "236df09e-1523-4232-bd1d-b2ff86dd42c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if platform=='datalab':\n",
+    "    # Relative path for DL users with access to file mount (available to DESI members upon request for testing purposes)\n",
+    "    desi_dir = \"../../../../../DESI/\"\n",
+    "    vac_dir = f\"../../{specprod}/nersc/\"\n",
+    "else:\n",
+    "    desi_dir = \"/global/cfs/cdirs/desi/\"\n",
+    "    vac_dir = f\"{desi_dir}public/edr/vac/edr/zcat/{specprod}/v1.0/\"\n",
+    "    # Currently in gqp for testing\n",
+    "    #vac_dir = f\"{desi_dir}science/gqp/vac/edr/zcat/{specprod}/v1.0/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "2ff2eb36-3f58-44f2-8a50-ce0e186eb334",
    "metadata": {},
    "outputs": [],
    "source": [
-    "specprod = \"fuji\"    # Internal name for the EDR\n",
-    "path_before = f\"/global/cfs/cdirs/desi/public/edr/spectro/redux/{specprod}/zcatalog/\"\n",
+    "# Original redshift catalog\n",
+    "path_before = f\"{desi_dir}spectro/redux/{specprod}/zcatalog/\"\n",
     "\n",
-    "file_before = path_before+\"zall-pix-fuji.fits\""
+    "# Public version\n",
+    "#path_before = f\"{desi_dir}public/edr/spectro/redux/{specprod}/zcatalog/\"\n",
+    "\n",
+    "if zcat_type=='healpix':\n",
+    "    file_before = path_before+\"zall-pix-fuji.fits\"\n",
+    "else:\n",
+    "    file_before = path_before+\"zall-tilecumulative-fuji.fits\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "id": "541d37b0-d2ac-43fb-9f28-5901443ec846",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Currently in gqp/ for testing\n",
-    "path_after = \"/global/cfs/cdirs/desi/science/gqp/vac/edr/zcat/v1.0/\"\n",
-    "\n",
-    "# When moved to final location\n",
-    "#path_after = \"/global/cfs/cdirs/desi/public/edr/vac/edr/zcat/v1.0/\"\n",
-    "\n",
-    "file_after = path_after+\"zall-pix-edr-vac.fits\""
+    "# VAC\n",
+    "if zcat_type=='healpix':\n",
+    "    file_after = vac_dir+\"zall-pix-edr-vac.fits\"\n",
+    "else:\n",
+    "    file_after = vac_dir+\"zall-tilecumulative-edr-vac.fits\"    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "id": "177eaace-b1b7-406b-ba21-681fa32ba65b",
    "metadata": {},
    "outputs": [
@@ -100,7 +170,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Filename: /global/cfs/cdirs/desi/public/edr/spectro/redux/fuji/zcatalog/zall-pix-fuji.fits\n",
+      "Filename: ../../../../../DESI/spectro/redux/fuji/zcatalog/zall-pix-fuji.fits\n",
       "No.    Name      Ver    Type      Cards   Dimensions   Format\n",
       "  0  PRIMARY       1 PrimaryHDU       4   ()      \n",
       "  1  ZCATALOG      1 BinTableHDU    333   2847435R x 130C   [K, 7A, 6A, J, J, D, D, K, D, 10D, K, 6A, 20A, K, D, J, D, D, E, E, E, K, B, 3A, D, J, I, 8A, J, J, 4A, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, I, E, E, E, E, K, 2A, E, E, E, E, 1A, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, D, D, I, E, I, I, E, E, E, E, D, E, D, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, J, L, K, L]   \n"
@@ -113,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "id": "8a0284aa-c676-4636-9c1b-24859610e4a6",
    "metadata": {},
    "outputs": [
@@ -121,10 +191,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Filename: /global/cfs/cdirs/desi/science/gqp/vac/edr/zcat/v1.0/zall-pix-edr-vac.fits\n",
+      "Filename: ../../fuji/nersc/zall-pix-edr-vac.fits\n",
       "No.    Name      Ver    Type      Cards   Dimensions   Format\n",
       "  0  PRIMARY       1 PrimaryHDU       4   ()      \n",
-      "  1  ZCATALOG      1 BinTableHDU    386   2451325R x 136C   [K, 7A, 6A, J, J, D, D, K, D, 10D, K, 6A, 20A, K, D, J, D, D, E, E, E, K, B, 3A, D, J, I, 8A, J, J, 4A, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, I, E, E, E, E, K, 2A, E, E, E, E, 1A, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, D, D, I, E, I, I, E, E, E, E, D, E, D, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, J, L, K, L, J, J, D, D, D, D]   \n"
+      "  1  ZCATALOG      1 BinTableHDU    384   2451325R x 135C   [K, 7A, 6A, J, J, D, D, K, D, 10D, K, 6A, 20A, K, D, J, D, D, E, E, E, K, B, 3A, D, J, I, 8A, J, J, 4A, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, I, E, E, E, E, K, 2A, E, E, E, E, 1A, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, D, D, I, E, I, I, E, E, E, E, D, E, D, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, J, L, K, L, D, D, D, J, J]   \n"
      ]
     }
    ],
@@ -134,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "id": "d7497283-6b59-4e4f-a804-91c979c8db70",
    "metadata": {},
    "outputs": [
@@ -142,8 +212,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4.11 s, sys: 733 ms, total: 4.84 s\n",
-      "Wall time: 5.17 s\n"
+      "CPU times: user 5.92 s, sys: 1.06 s, total: 6.97 s\n",
+      "Wall time: 6.97 s\n"
      ]
     }
    ],
@@ -154,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "id": "aec0d643-2116-42b3-b4ac-d7627b264a98",
    "metadata": {},
    "outputs": [
@@ -162,8 +232,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 5.38 s, sys: 649 ms, total: 6.03 s\n",
-      "Wall time: 6.33 s\n"
+      "CPU times: user 7.34 s, sys: 1.15 s, total: 8.49 s\n",
+      "Wall time: 8.49 s\n"
      ]
     }
    ],
@@ -182,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "0b559814-55eb-4f27-9f25-0c97347bdbe6",
    "metadata": {},
    "outputs": [
@@ -190,7 +260,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'SPGRPVAL', 'Z', 'ZERR', 'ZWARN', 'CHI2', 'COEFF', 'NPIXELS', 'SPECTYPE', 'SUBTYPE', 'NCOEFF', 'DELTACHI2', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'PMRA', 'PMDEC', 'REF_EPOCH', 'FA_TARGET', 'FA_TYPE', 'OBJTYPE', 'SUBPRIORITY', 'OBSCONDITIONS', 'RELEASE', 'BRICKNAME', 'BRICKID', 'BRICK_OBJID', 'MORPHTYPE', 'EBV', 'FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 'FLUX_IVAR_G', 'FLUX_IVAR_R', 'FLUX_IVAR_Z', 'FLUX_IVAR_W1', 'FLUX_IVAR_W2', 'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'MASKBITS', 'SERSIC', 'SHAPE_R', 'SHAPE_E1', 'SHAPE_E2', 'REF_ID', 'REF_CAT', 'GAIA_PHOT_G_MEAN_MAG', 'GAIA_PHOT_BP_MEAN_MAG', 'GAIA_PHOT_RP_MEAN_MAG', 'PARALLAX', 'PHOTSYS', 'PRIORITY_INIT', 'NUMOBS_INIT', 'CMX_TARGET', 'DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET', 'SV1_DESI_TARGET', 'SV1_BGS_TARGET', 'SV1_MWS_TARGET', 'SV1_SCND_TARGET', 'SV2_DESI_TARGET', 'SV2_BGS_TARGET', 'SV2_MWS_TARGET', 'SV2_SCND_TARGET', 'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET', 'PLATE_RA', 'PLATE_DEC', 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE', 'MEAN_DELTA_X', 'RMS_DELTA_X', 'MEAN_DELTA_Y', 'RMS_DELTA_Y', 'MEAN_FIBER_RA', 'STD_FIBER_RA', 'MEAN_FIBER_DEC', 'STD_FIBER_DEC', 'MEAN_PSF_TO_FIBER_SPECFLUX', 'TSNR2_GPBDARK_B', 'TSNR2_ELG_B', 'TSNR2_GPBBRIGHT_B', 'TSNR2_LYA_B', 'TSNR2_BGS_B', 'TSNR2_GPBBACKUP_B', 'TSNR2_QSO_B', 'TSNR2_LRG_B', 'TSNR2_GPBDARK_R', 'TSNR2_ELG_R', 'TSNR2_GPBBRIGHT_R', 'TSNR2_LYA_R', 'TSNR2_BGS_R', 'TSNR2_GPBBACKUP_R', 'TSNR2_QSO_R', 'TSNR2_LRG_R', 'TSNR2_GPBDARK_Z', 'TSNR2_ELG_Z', 'TSNR2_GPBBRIGHT_Z', 'TSNR2_LYA_Z', 'TSNR2_BGS_Z', 'TSNR2_GPBBACKUP_Z', 'TSNR2_QSO_Z', 'TSNR2_LRG_Z', 'TSNR2_GPBDARK', 'TSNR2_ELG', 'TSNR2_GPBBRIGHT', 'TSNR2_LYA', 'TSNR2_BGS', 'TSNR2_GPBBACKUP', 'TSNR2_QSO', 'TSNR2_LRG', 'SV_NSPEC', 'SV_PRIMARY', 'ZCAT_NSPEC', 'ZCAT_PRIMARY', 'FIRSTNIGHT', 'LASTNIGHT', 'MIN_MJD', 'CENTER_MJD', 'MEAN_MJD', 'MAX_MJD']\n"
+      "['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'SPGRPVAL', 'Z', 'ZERR', 'ZWARN', 'CHI2', 'COEFF', 'NPIXELS', 'SPECTYPE', 'SUBTYPE', 'NCOEFF', 'DELTACHI2', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'PMRA', 'PMDEC', 'REF_EPOCH', 'FA_TARGET', 'FA_TYPE', 'OBJTYPE', 'SUBPRIORITY', 'OBSCONDITIONS', 'RELEASE', 'BRICKNAME', 'BRICKID', 'BRICK_OBJID', 'MORPHTYPE', 'EBV', 'FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 'FLUX_IVAR_G', 'FLUX_IVAR_R', 'FLUX_IVAR_Z', 'FLUX_IVAR_W1', 'FLUX_IVAR_W2', 'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'MASKBITS', 'SERSIC', 'SHAPE_R', 'SHAPE_E1', 'SHAPE_E2', 'REF_ID', 'REF_CAT', 'GAIA_PHOT_G_MEAN_MAG', 'GAIA_PHOT_BP_MEAN_MAG', 'GAIA_PHOT_RP_MEAN_MAG', 'PARALLAX', 'PHOTSYS', 'PRIORITY_INIT', 'NUMOBS_INIT', 'CMX_TARGET', 'DESI_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET', 'SV1_DESI_TARGET', 'SV1_BGS_TARGET', 'SV1_MWS_TARGET', 'SV1_SCND_TARGET', 'SV2_DESI_TARGET', 'SV2_BGS_TARGET', 'SV2_MWS_TARGET', 'SV2_SCND_TARGET', 'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET', 'PLATE_RA', 'PLATE_DEC', 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE', 'MEAN_DELTA_X', 'RMS_DELTA_X', 'MEAN_DELTA_Y', 'RMS_DELTA_Y', 'MEAN_FIBER_RA', 'STD_FIBER_RA', 'MEAN_FIBER_DEC', 'STD_FIBER_DEC', 'MEAN_PSF_TO_FIBER_SPECFLUX', 'TSNR2_GPBDARK_B', 'TSNR2_ELG_B', 'TSNR2_GPBBRIGHT_B', 'TSNR2_LYA_B', 'TSNR2_BGS_B', 'TSNR2_GPBBACKUP_B', 'TSNR2_QSO_B', 'TSNR2_LRG_B', 'TSNR2_GPBDARK_R', 'TSNR2_ELG_R', 'TSNR2_GPBBRIGHT_R', 'TSNR2_LYA_R', 'TSNR2_BGS_R', 'TSNR2_GPBBACKUP_R', 'TSNR2_QSO_R', 'TSNR2_LRG_R', 'TSNR2_GPBDARK_Z', 'TSNR2_ELG_Z', 'TSNR2_GPBBRIGHT_Z', 'TSNR2_LYA_Z', 'TSNR2_BGS_Z', 'TSNR2_GPBBACKUP_Z', 'TSNR2_QSO_Z', 'TSNR2_LRG_Z', 'TSNR2_GPBDARK', 'TSNR2_ELG', 'TSNR2_GPBBRIGHT', 'TSNR2_LYA', 'TSNR2_BGS', 'TSNR2_GPBBACKUP', 'TSNR2_QSO', 'TSNR2_LRG', 'SV_NSPEC', 'SV_PRIMARY', 'ZCAT_NSPEC', 'ZCAT_PRIMARY', 'MIN_MJD', 'MEAN_MJD', 'MAX_MJD', 'FIRSTNIGHT', 'LASTNIGHT']\n"
      ]
     }
    ],
@@ -201,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "id": "49130281-b070-486d-aea0-96f515c8886f",
    "metadata": {},
    "outputs": [
@@ -220,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "id": "72a0ef13-a8b8-470d-9fcd-bb85b60a8560",
    "metadata": {},
    "outputs": [],
@@ -230,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "id": "66940ae9-ef0e-4f01-a3c7-5f5ddd0533c4",
    "metadata": {},
    "outputs": [],
@@ -252,14 +322,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "id": "7ef6ab43-066d-42b1-b084-97fcabfa1966",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Columns that shouldn't have changed (except removing COEFF because it doesn't work with Table.setdiff)\n",
     "\n",
-    "common_cols = ['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'SPGRPVAL', 'Z', 'ZERR', 'ZWARN', 'CHI2', \\\n",
+    "common_cols = ['TARGETID', 'SURVEY', 'PROGRAM', 'SPGRPVAL', 'Z', 'ZERR', 'ZWARN', 'CHI2', \\\n",
     "             'NPIXELS', 'SPECTYPE', 'SUBTYPE', 'NCOEFF', 'DELTACHI2', 'COADD_FIBERSTATUS', \\\n",
     "             'TARGET_RA', 'TARGET_DEC', 'PMRA', 'PMDEC', 'REF_EPOCH', 'FA_TARGET', 'FA_TYPE', 'OBJTYPE', 'SUBPRIORITY', \\\n",
     "             'OBSCONDITIONS', 'RELEASE', 'BRICKNAME', 'BRICKID', 'BRICK_OBJID', 'MORPHTYPE', 'EBV', \\\n",
@@ -277,12 +347,18 @@
     "             'TSNR2_BGS_R', 'TSNR2_GPBBACKUP_R', 'TSNR2_QSO_R', 'TSNR2_LRG_R', 'TSNR2_GPBDARK_Z', 'TSNR2_ELG_Z', \\\n",
     "             'TSNR2_GPBBRIGHT_Z', 'TSNR2_LYA_Z', 'TSNR2_BGS_Z', 'TSNR2_GPBBACKUP_Z', 'TSNR2_QSO_Z', 'TSNR2_LRG_Z', \\\n",
     "             'TSNR2_GPBDARK', 'TSNR2_ELG', 'TSNR2_GPBBRIGHT', 'TSNR2_LYA', 'TSNR2_BGS', 'TSNR2_GPBBACKUP', 'TSNR2_QSO', \\\n",
-    "             'TSNR2_LRG', 'SV_NSPEC', 'SV_PRIMARY', 'ZCAT_NSPEC', 'ZCAT_PRIMARY']"
+    "             'TSNR2_LRG', 'SV_NSPEC', 'SV_PRIMARY', 'ZCAT_NSPEC', 'ZCAT_PRIMARY']\n",
+    "\n",
+    "if zcat_type=='cumulative':\n",
+    "    common_cols.extend(['LASTNIGHT','TILEID'])\n",
+    "    \n",
+    "if zcat_type=='healpix':\n",
+    "    common_cols.extend(['HEALPIX'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "id": "9ac333b9-8354-43b7-b4ee-6c79494d1591",
    "metadata": {},
    "outputs": [],
@@ -296,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "id": "b2fa3202-307f-4847-a15f-086cb44ff328",
    "metadata": {},
    "outputs": [],
@@ -307,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "id": "335e4b43-8b91-4934-8500-179764ec95af",
    "metadata": {},
    "outputs": [],
@@ -333,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "id": "cc4b8306-9f01-4073-992f-b7ee6eb31017",
    "metadata": {},
    "outputs": [
@@ -357,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "id": "234a3369-6d4b-4eb3-8577-df69cc87648a",
    "metadata": {},
    "outputs": [
@@ -365,8 +441,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 40.5 s, sys: 2.37 s, total: 42.9 s\n",
-      "Wall time: 42.9 s\n"
+      "CPU times: user 1min 25s, sys: 6.01 s, total: 1min 31s\n",
+      "Wall time: 1min 31s\n"
      ]
     }
    ],
@@ -378,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "id": "808904b3-0639-4f40-a3de-c533e91dac3f",
    "metadata": {},
    "outputs": [
@@ -387,7 +463,7 @@
      "output_type": "stream",
      "text": [
       " \n",
-      "SUCCESS: Values unchanged as expected for: ['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'SPGRPVAL', 'Z', 'ZERR', 'ZWARN', 'CHI2', 'NPIXELS', 'SPECTYPE', 'SUBTYPE', 'NCOEFF', 'DELTACHI2', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'PMRA', 'PMDEC', 'REF_EPOCH', 'FA_TARGET', 'FA_TYPE', 'OBJTYPE', 'SUBPRIORITY', 'OBSCONDITIONS', 'RELEASE', 'BRICKNAME', 'BRICKID', 'BRICK_OBJID', 'MORPHTYPE', 'EBV', 'FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 'FLUX_IVAR_G', 'FLUX_IVAR_R', 'FLUX_IVAR_Z', 'FLUX_IVAR_W1', 'FLUX_IVAR_W2', 'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'MASKBITS', 'SERSIC', 'SHAPE_R', 'SHAPE_E1', 'SHAPE_E2', 'REF_ID', 'REF_CAT', 'GAIA_PHOT_G_MEAN_MAG', 'GAIA_PHOT_BP_MEAN_MAG', 'GAIA_PHOT_RP_MEAN_MAG', 'PARALLAX', 'PHOTSYS', 'PRIORITY_INIT', 'NUMOBS_INIT', 'CMX_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET', 'SV1_BGS_TARGET', 'SV2_DESI_TARGET', 'SV2_BGS_TARGET', 'SV2_MWS_TARGET', 'SV2_SCND_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'PLATE_RA', 'PLATE_DEC', 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE', 'TSNR2_GPBDARK_B', 'TSNR2_ELG_B', 'TSNR2_GPBBRIGHT_B', 'TSNR2_LYA_B', 'TSNR2_BGS_B', 'TSNR2_GPBBACKUP_B', 'TSNR2_QSO_B', 'TSNR2_LRG_B', 'TSNR2_GPBDARK_R', 'TSNR2_ELG_R', 'TSNR2_GPBBRIGHT_R', 'TSNR2_LYA_R', 'TSNR2_BGS_R', 'TSNR2_GPBBACKUP_R', 'TSNR2_QSO_R', 'TSNR2_LRG_R', 'TSNR2_GPBDARK_Z', 'TSNR2_ELG_Z', 'TSNR2_GPBBRIGHT_Z', 'TSNR2_LYA_Z', 'TSNR2_BGS_Z', 'TSNR2_GPBBACKUP_Z', 'TSNR2_QSO_Z', 'TSNR2_LRG_Z', 'TSNR2_GPBDARK', 'TSNR2_ELG', 'TSNR2_GPBBRIGHT', 'TSNR2_LYA', 'TSNR2_BGS', 'TSNR2_GPBBACKUP', 'TSNR2_QSO', 'TSNR2_LRG', 'SV_NSPEC', 'SV_PRIMARY', 'ZCAT_NSPEC', 'ZCAT_PRIMARY']\n",
+      "SUCCESS: Values unchanged as expected for: ['TARGETID', 'SURVEY', 'PROGRAM', 'SPGRPVAL', 'Z', 'ZERR', 'ZWARN', 'CHI2', 'NPIXELS', 'SPECTYPE', 'SUBTYPE', 'NCOEFF', 'DELTACHI2', 'COADD_FIBERSTATUS', 'TARGET_RA', 'TARGET_DEC', 'PMRA', 'PMDEC', 'REF_EPOCH', 'FA_TARGET', 'FA_TYPE', 'OBJTYPE', 'SUBPRIORITY', 'OBSCONDITIONS', 'RELEASE', 'BRICKNAME', 'BRICKID', 'BRICK_OBJID', 'MORPHTYPE', 'EBV', 'FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2', 'FLUX_IVAR_G', 'FLUX_IVAR_R', 'FLUX_IVAR_Z', 'FLUX_IVAR_W1', 'FLUX_IVAR_W2', 'FIBERFLUX_G', 'FIBERFLUX_R', 'FIBERFLUX_Z', 'FIBERTOTFLUX_G', 'FIBERTOTFLUX_R', 'FIBERTOTFLUX_Z', 'MASKBITS', 'SERSIC', 'SHAPE_R', 'SHAPE_E1', 'SHAPE_E2', 'REF_ID', 'REF_CAT', 'GAIA_PHOT_G_MEAN_MAG', 'GAIA_PHOT_BP_MEAN_MAG', 'GAIA_PHOT_RP_MEAN_MAG', 'PARALLAX', 'PHOTSYS', 'PRIORITY_INIT', 'NUMOBS_INIT', 'CMX_TARGET', 'BGS_TARGET', 'MWS_TARGET', 'SCND_TARGET', 'SV1_BGS_TARGET', 'SV2_DESI_TARGET', 'SV2_BGS_TARGET', 'SV2_MWS_TARGET', 'SV2_SCND_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'PLATE_RA', 'PLATE_DEC', 'COADD_NUMEXP', 'COADD_EXPTIME', 'COADD_NUMNIGHT', 'COADD_NUMTILE', 'TSNR2_GPBDARK_B', 'TSNR2_ELG_B', 'TSNR2_GPBBRIGHT_B', 'TSNR2_LYA_B', 'TSNR2_BGS_B', 'TSNR2_GPBBACKUP_B', 'TSNR2_QSO_B', 'TSNR2_LRG_B', 'TSNR2_GPBDARK_R', 'TSNR2_ELG_R', 'TSNR2_GPBBRIGHT_R', 'TSNR2_LYA_R', 'TSNR2_BGS_R', 'TSNR2_GPBBACKUP_R', 'TSNR2_QSO_R', 'TSNR2_LRG_R', 'TSNR2_GPBDARK_Z', 'TSNR2_ELG_Z', 'TSNR2_GPBBRIGHT_Z', 'TSNR2_LYA_Z', 'TSNR2_BGS_Z', 'TSNR2_GPBBACKUP_Z', 'TSNR2_QSO_Z', 'TSNR2_LRG_Z', 'TSNR2_GPBDARK', 'TSNR2_ELG', 'TSNR2_GPBBRIGHT', 'TSNR2_LYA', 'TSNR2_BGS', 'TSNR2_GPBBACKUP', 'TSNR2_QSO', 'TSNR2_LRG', 'SV_NSPEC', 'SV_PRIMARY', 'ZCAT_NSPEC', 'ZCAT_PRIMARY', 'HEALPIX']\n",
       " \n",
       "SURVEY\n",
       "------\n",
@@ -412,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "id": "8013eb67-920b-4640-bd02-adc93395a900",
    "metadata": {},
    "outputs": [
@@ -420,8 +496,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.06 s, sys: 264 ms, total: 7.32 s\n",
-      "Wall time: 7.31 s\n"
+      "CPU times: user 17.1 s, sys: 1.81 s, total: 18.9 s\n",
+      "Wall time: 18.9 s\n"
      ]
     }
    ],
@@ -433,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "id": "0663badd-53f1-409b-9c26-f5b915f54879",
    "metadata": {},
    "outputs": [
@@ -468,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "id": "979db139-b0df-4a5a-979b-e569ae9905ee",
    "metadata": {},
    "outputs": [],
@@ -486,6 +562,8 @@
     "    print(np.unique(diff_zcat['SURVEY']))\n",
     "    print(np.unique(diff_zcat['PROGRAM']))\n",
     "\n",
+    "    if Ndiff==0:\n",
+    "        return([0])\n",
     "    # Table '1' = after; Table '2' = before\n",
     "    test = join(diff_zcat, tb[fix_cols], join_type='left', keys=['TARGETID','SURVEY','PROGRAM'], table_names=['1','2'])\n",
     "\n",
@@ -534,7 +612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "id": "890b8e6b-4748-4710-b5f6-59b3cdb41365",
    "metadata": {},
    "outputs": [
@@ -558,8 +636,8 @@
       "   N(rows with minimum relative difference>None) = 1039\n",
       "   N(rows with new smaller value) = 1039, with median=-4294967296.0\n",
       "   N(rows with new larger value) = 0\n",
-      "CPU times: user 8.8 s, sys: 184 ms, total: 8.99 s\n",
-      "Wall time: 8.97 s\n"
+      "CPU times: user 22.8 s, sys: 486 ms, total: 23.3 s\n",
+      "Wall time: 23.2 s\n"
      ]
     }
    ],
@@ -567,7 +645,12 @@
     "%%time\n",
     "# Should change for just CMX targets now set to have DESI_TARGET=0\n",
     "fix2_cols =  ['TARGETID', 'SURVEY', 'PROGRAM', 'DESI_TARGET']\n",
-    "N2_correct = 1039\n",
+    "\n",
+    "if zcat_type=='healpix':\n",
+    "    N2_correct = 1039\n",
+    "else:\n",
+    "    N2_correct = 0\n",
+    "    \n",
     "survey2_correct = 'cmx'\n",
     "\n",
     "diff_zcat = check_fix_cols(fix2_cols, N2_correct)"
@@ -575,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 27,
    "id": "ff711513-ed2c-4d01-a9c3-c3474bf30967",
    "metadata": {},
    "outputs": [
@@ -610,8 +693,8 @@
       "==============================================================\n",
       "CHECK: New values should always be LARGER and in SV1-dark only\n",
       "==============================================================\n",
-      "CPU times: user 8.89 s, sys: 148 ms, total: 9.04 s\n",
-      "Wall time: 9.02 s\n"
+      "CPU times: user 23.3 s, sys: 644 ms, total: 24 s\n",
+      "Wall time: 23.9 s\n"
      ]
     }
    ],
@@ -621,19 +704,21 @@
     "#   39 rows for SV1_DESI_TARGET + SV1_SCND_TARGET) + 3 rows for just SV1_MWS_TARGET\n",
     "fix3_cols =  ['TARGETID', 'SURVEY', 'PROGRAM', \\\n",
     "             'SV1_DESI_TARGET', 'SV1_MWS_TARGET', 'SV1_SCND_TARGET']\n",
-    "N3_correct = 42\n",
-    "survey3_correct = 'sv1'\n",
     "\n",
-    "diff_zcat = check_fix_cols(fix3_cols, N3_correct)\n",
+    "if zcat_type=='healpix':\n",
+    "    N3_correct = 42\n",
+    "    survey3_correct = 'sv1'\n",
     "\n",
-    "print(\"==============================================================\")\n",
-    "print(\"CHECK: New values should always be LARGER and in SV1-dark only\")\n",
-    "print(\"==============================================================\")"
+    "    diff_zcat = check_fix_cols(fix3_cols, N3_correct)\n",
+    "\n",
+    "    print(\"==============================================================\")\n",
+    "    print(\"CHECK: New values should always be LARGER and in SV1-dark only\")\n",
+    "    print(\"==============================================================\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 28,
    "id": "77727296-12e3-4192-ace7-22c63f964d0e",
    "metadata": {},
    "outputs": [
@@ -671,8 +756,8 @@
       "TARGETID\n",
       "--------\n",
       "    9999\n",
-      "CPU times: user 9.2 s, sys: 240 ms, total: 9.44 s\n",
-      "Wall time: 9.43 s\n"
+      "CPU times: user 24.5 s, sys: 611 ms, total: 25.1 s\n",
+      "Wall time: 25 s\n"
      ]
     }
    ],
@@ -682,21 +767,23 @@
     "# Expecting for SV3 (bright|dark) for ToO (RELEASE=9999 from decode_targetid)\n",
     "fix4_cols =  ['TARGETID', 'SURVEY', 'PROGRAM', \\\n",
     "             'SV3_DESI_TARGET', 'SV3_BGS_TARGET', 'SV3_MWS_TARGET', 'SV3_SCND_TARGET']\n",
-    "N4_correct = 230\n",
-    "survey4_correct = 'sv3'\n",
-    "release4_correct = 9999\n",
     "\n",
-    "diff_zcat = check_fix_cols(fix4_cols, N4_correct)\n",
+    "if zcat_type=='healpix':\n",
+    "    N4_correct = 230\n",
+    "    survey4_correct = 'sv3'\n",
+    "    release4_correct = 9999\n",
     "\n",
-    "print(\"==============================================================\")\n",
-    "print(\"If the change is for ToO then RELEASE = 9999 from TARGETID\")\n",
-    "_,_,release,_,_,_ = decode_targetid(diff_zcat['TARGETID'])\n",
-    "print(np.unique(release))"
+    "    diff_zcat = check_fix_cols(fix4_cols, N4_correct)\n",
+    "\n",
+    "    print(\"==============================================================\")\n",
+    "    print(\"If the change is for ToO then RELEASE = 9999 from TARGETID\")\n",
+    "    _,_,release,_,_,_ = decode_targetid(diff_zcat['TARGETID'])\n",
+    "    print(np.unique(release))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 29,
    "id": "86b81e35-c867-4bd6-a9a6-ccbe1ae10d01",
    "metadata": {},
    "outputs": [
@@ -705,8 +792,8 @@
      "output_type": "stream",
      "text": [
       "['TARGETID', 'SURVEY', 'PROGRAM', 'MEAN_DELTA_X', 'RMS_DELTA_X', 'MEAN_DELTA_Y', 'RMS_DELTA_Y', 'MEAN_PSF_TO_FIBER_SPECFLUX']\n",
-      "N(rows) with a difference = 150153\n",
-      "Number as expected?  True\n",
+      "N(rows) with a difference = 138509\n",
+      "Number as expected?  False\n",
       " \n",
       "Differences found in the following Surveys & Programs: \n",
       " SURVEY\n",
@@ -724,17 +811,17 @@
       "  other\n",
       "======== STATS FOR INDIVIDUAL COLUMNS ========\n",
       "Column = MEAN_DELTA_X\n",
-      "   N(rows with minimum relative difference>None) = 144153\n",
-      "   N(rows with new smaller value) = 73759, with median=-0.4724545478820801\n",
-      "   N(rows with new larger value) = 70394, with median=0.46897727251052856\n",
+      "   N(rows with minimum relative difference>None) = 138332\n",
+      "   N(rows with new smaller value) = 70830, with median=-0.5089362263679504\n",
+      "   N(rows with new larger value) = 67502, with median=0.505854070186615\n",
       "Column = RMS_DELTA_X\n",
       "   N(rows with minimum relative difference>None) = 138377\n",
       "   N(rows with new smaller value) = 132371, with median=-1.0288488864898682\n",
       "   N(rows with new larger value) = 6006, with median=0.0010273351799696684\n",
       "Column = MEAN_DELTA_Y\n",
-      "   N(rows with minimum relative difference>None) = 144170\n",
-      "   N(rows with new smaller value) = 71592, with median=-0.47118330001831055\n",
-      "   N(rows with new larger value) = 72578, with median=0.48530441522598267\n",
+      "   N(rows with minimum relative difference>None) = 138287\n",
+      "   N(rows with new smaller value) = 68680, with median=-0.5090000033378601\n",
+      "   N(rows with new larger value) = 69607, with median=0.5219999551773071\n",
       "Column = RMS_DELTA_Y\n",
       "   N(rows with minimum relative difference>None) = 138348\n",
       "   N(rows with new smaller value) = 132394, with median=-1.0453534126281738\n",
@@ -757,8 +844,14 @@
     "fix5_cols =  ['TARGETID', 'SURVEY', 'PROGRAM', \\\n",
     "             'MEAN_DELTA_X', 'RMS_DELTA_X', 'MEAN_DELTA_Y', 'RMS_DELTA_Y', \\\n",
     "             'MEAN_PSF_TO_FIBER_SPECFLUX']\n",
-    "N5_correct = 150153\n",
     "\n",
+    "#- TODO: investigate the numbers more closely because small differences at numerical precision level \n",
+    "#  can influence the exact numbers (expected behavior described below is consistent so far)\n",
+    "if zcat_type=='healpix':\n",
+    "    N5_correct = 150153\n",
+    "else:\n",
+    "    N5_correct = 69220\n",
+    "    \n",
     "diff_zcat = check_fix_cols(fix5_cols, N5_correct)\n",
     "print(\"==============================================================\")\n",
     "print(\" Expecting the following for Differences: \")\n",
@@ -769,7 +862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 30,
    "id": "e456caf5-7524-4a76-858d-9d36a2a80aff",
    "metadata": {},
    "outputs": [
@@ -778,7 +871,7 @@
      "output_type": "stream",
      "text": [
       "['TARGETID', 'SURVEY', 'PROGRAM', 'STD_FIBER_RA']\n",
-      "N(rows) with a difference = 1441069\n",
+      "N(rows) with a difference = 1434375\n",
       "Number as expected?  True\n",
       " \n",
       "Differences found in the following Surveys & Programs: \n",
@@ -797,9 +890,9 @@
       "  other\n",
       "======== STATS FOR INDIVIDUAL COLUMNS ========\n",
       "Column = STD_FIBER_RA\n",
-      "   N(rows with minimum relative difference>None) = 1441069\n",
-      "   N(rows with new smaller value) = 1432039, with median=-0.020463012158870697\n",
-      "   N(rows with new larger value) = 9030, with median=1.0231815394945443e-10\n",
+      "   N(rows with minimum relative difference>None) = 1434375\n",
+      "   N(rows with new smaller value) = 1433215, with median=-0.03680609166622162\n",
+      "   N(rows with new larger value) = 1160, with median=0.008712729439139366\n",
       "==============================================================\n",
       "Expecting most values of STD_FIBER_RA to be smaller\n"
      ]
@@ -808,7 +901,13 @@
    "source": [
     "# Should change for most rows because of cos(dec) term\n",
     "fix6_cols =  ['TARGETID', 'SURVEY', 'PROGRAM', 'STD_FIBER_RA']\n",
-    "N6_correct = 1441069\n",
+    "\n",
+    "#- TODO: investigate the numbers more closely because small differences at numerical precision level \n",
+    "#  can influence the exact numbers (expected behavior described below is consistent so far)\n",
+    "if zcat_type=='healpix':\n",
+    "    N6_correct = 1434375\n",
+    "else:\n",
+    "    N6_correct = 1197838\n",
     "\n",
     "diff_zcat = check_fix_cols(fix6_cols, N6_correct)\n",
     "print(\"==============================================================\")\n",
@@ -817,7 +916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 31,
    "id": "bc2e333a-2e14-41d6-b7cb-cb2e98130cfb",
    "metadata": {},
    "outputs": [
@@ -826,7 +925,7 @@
      "output_type": "stream",
      "text": [
       "['TARGETID', 'SURVEY', 'PROGRAM', 'MEAN_FIBER_RA', 'MEAN_FIBER_DEC', 'STD_FIBER_DEC']\n",
-      "N(rows) with a difference = 656071\n",
+      "N(rows) with a difference = 155330\n",
       "Number as expected?  True\n",
       " \n",
       "Differences found in the following Surveys & Programs: \n",
@@ -845,17 +944,17 @@
       "  other\n",
       "======== STATS FOR INDIVIDUAL COLUMNS ========\n",
       "Column = MEAN_FIBER_RA\n",
-      "   N(rows with minimum relative difference>None) = 468323\n",
-      "   N(rows with new smaller value) = 226037, with median=-2.842170943040401e-14\n",
-      "   N(rows with new larger value) = 242286, with median=2.842170943040401e-14\n",
+      "   N(rows with minimum relative difference>None) = 155326\n",
+      "   N(rows with new smaller value) = 69893, with median=-0.002655959640179617\n",
+      "   N(rows with new larger value) = 85433, with median=0.004128272000656352\n",
       "Column = MEAN_FIBER_DEC\n",
-      "   N(rows with minimum relative difference>None) = 467057\n",
-      "   N(rows with new smaller value) = 229103, with median=-7.105427357601002e-15\n",
-      "   N(rows with new larger value) = 237954, with median=7.105427357601002e-15\n",
+      "   N(rows with minimum relative difference>None) = 155327\n",
+      "   N(rows with new smaller value) = 73457, with median=-0.002289701038964864\n",
+      "   N(rows with new larger value) = 81870, with median=0.0027925135916015975\n",
       "Column = STD_FIBER_DEC\n",
-      "   N(rows with minimum relative difference>None) = 156322\n",
-      "   N(rows with new smaller value) = 151220, with median=-13.610631942749023\n",
-      "   N(rows with new larger value) = 5102, with median=0.007693402469158173\n",
+      "   N(rows with minimum relative difference>None) = 155328\n",
+      "   N(rows with new smaller value) = 151217, with median=-13.61166763305664\n",
+      "   N(rows with new larger value) = 4111, with median=0.010217368602752686\n",
       "==============================================================\n",
       " Expecting the following for Differences: \n",
       "  - Most values of STD_FIBER_DEC should be smaller (some unchanged)\n",
@@ -865,9 +964,11 @@
       " Besides small differences, a subset will have >10% changes \n",
       " Namely, ~10-15k rows should have larger MEAN_FIBER_{RA|DEC}\n",
       " \n",
-      "['TARGETID', 'SURVEY', 'PROGRAM', 'MEAN_FIBER_RA', 'MEAN_FIBER_DEC', 'STD_FIBER_DEC']\n",
-      "N(rows) with a difference = 656071\n",
-      "Number as expected?  True\n",
+      " Warning: this calculation is not relevant for STD_FIBER_DEC. \n",
+      " \n",
+      "['TARGETID', 'SURVEY', 'PROGRAM', 'MEAN_FIBER_RA', 'MEAN_FIBER_DEC']\n",
+      "N(rows) with a difference = 155329\n",
+      "Number as expected?  False\n",
       " \n",
       "Differences found in the following Surveys & Programs: \n",
       " SURVEY\n",
@@ -885,33 +986,13 @@
       "  other\n",
       "======== STATS FOR INDIVIDUAL COLUMNS ========\n",
       "Column = MEAN_FIBER_RA\n",
-      "   N(rows with minimum relative difference>0.1) = 13351\n",
+      "   N(rows with minimum relative difference>0.1) = 13348\n",
       "   N(rows with new smaller value) = 0\n",
-      "   N(rows with new larger value) = 13351, with median=35.688923336893104\n",
+      "   N(rows with new larger value) = 13348, with median=35.68955673854732\n",
       "Column = MEAN_FIBER_DEC\n",
-      "   N(rows with minimum relative difference>0.1) = 13920\n",
+      "   N(rows with minimum relative difference>0.1) = 13916\n",
       "   N(rows with new smaller value) = 795, with median=-0.30286501446696995\n",
-      "   N(rows with new larger value) = 13125, with median=0.6252934536717114\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_184409/4253660386.py:24: RuntimeWarning: divide by zero encountered in true_divide\n",
-      "  is_diff = abs((test[col+'_1']-test[col+'_2'])/test[col+'_1'])>large_diff\n",
-      "/tmp/ipykernel_184409/4253660386.py:24: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  is_diff = abs((test[col+'_1']-test[col+'_2'])/test[col+'_1'])>large_diff\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Column = STD_FIBER_DEC\n",
-      "   N(rows with minimum relative difference>0.1) = 154349\n",
-      "   N(rows with new smaller value) = 150874, with median=-13.651728630065918\n",
-      "   N(rows with new larger value) = 3475, with median=0.01154012605547905\n"
+      "   N(rows with new larger value) = 13121, with median=0.6253481694958282\n"
      ]
     }
    ],
@@ -919,7 +1000,11 @@
     "# Without the STD_FIBER_RA which has a cos(dec) term\n",
     "fix7_cols =  ['TARGETID', 'SURVEY', 'PROGRAM', \\\n",
     "             'MEAN_FIBER_RA', 'MEAN_FIBER_DEC', 'STD_FIBER_DEC']\n",
-    "N7_correct = 656071\n",
+    "\n",
+    "if zcat_type=='healpix':\n",
+    "    N7_correct = 155330\n",
+    "else:\n",
+    "    N7_correct = 516125\n",
     "\n",
     "diff_zcat = check_fix_cols(fix7_cols, N7_correct)\n",
     "print(\"==============================================================\")\n",
@@ -931,9 +1016,12 @@
     "print(\" Besides small differences, a subset will have >10% changes \")\n",
     "print(\" Namely, ~10-15k rows should have larger MEAN_FIBER_{RA|DEC}\")\n",
     "print(\" \")\n",
+    "print(\" Warning: this calculation is not relevant for STD_FIBER_DEC. \")\n",
+    "print(\" \")\n",
     "\n",
     "# Call again with a threshold of 10% difference\n",
-    "diff_zcat = check_fix_cols(fix7_cols, N7_correct,large_diff=0.10)\n"
+    "diff_zcat = check_fix_cols(['TARGETID', 'SURVEY', 'PROGRAM', \\\n",
+    "             'MEAN_FIBER_RA', 'MEAN_FIBER_DEC'], N7_correct,large_diff=0.10)\n"
    ]
   },
   {
@@ -946,7 +1034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 32,
    "id": "c7385672-29b2-4356-a1eb-e3fcf2a927bf",
    "metadata": {},
    "outputs": [],
@@ -957,7 +1045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 33,
    "id": "2be225eb-bfcb-4000-8bd6-d7b16f7a18a2",
    "metadata": {},
    "outputs": [],
@@ -968,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 34,
    "id": "33c0d15b-3866-4b6d-9ab4-525adad2eda2",
    "metadata": {},
    "outputs": [],
@@ -978,7 +1066,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 35,
    "id": "1934492e-870d-4e57-8a79-2145c5393827",
    "metadata": {},
    "outputs": [],
@@ -989,7 +1077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 36,
    "id": "c3f035a7-4916-4000-b47e-74933e40839f",
    "metadata": {},
    "outputs": [
@@ -1017,7 +1105,6 @@
        "      <th>FIRSTNIGHT</th>\n",
        "      <th>LASTNIGHT</th>\n",
        "      <th>MIN_MJD</th>\n",
-       "      <th>CENTER_MJD</th>\n",
        "      <th>MEAN_MJD</th>\n",
        "      <th>MAX_MJD</th>\n",
        "      <th>MAX_MIN_DIFF</th>\n",
@@ -1031,25 +1118,22 @@
        "      <td>2.451325e+06</td>\n",
        "      <td>2.451325e+06</td>\n",
        "      <td>2.451325e+06</td>\n",
-       "      <td>2.451325e+06</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>mean</th>\n",
        "      <td>2.021002e+07</td>\n",
-       "      <td>2.021015e+07</td>\n",
+       "      <td>2.021016e+07</td>\n",
        "      <td>5.930167e+04</td>\n",
-       "      <td>5.930696e+04</td>\n",
        "      <td>5.930609e+04</td>\n",
        "      <td>5.931224e+04</td>\n",
        "      <td>10.565186</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>std</th>\n",
-       "      <td>1.757134e+03</td>\n",
-       "      <td>1.495939e+03</td>\n",
+       "      <td>1.761005e+03</td>\n",
+       "      <td>1.491326e+03</td>\n",
        "      <td>4.160221e+01</td>\n",
-       "      <td>3.726858e+01</td>\n",
        "      <td>3.846983e+01</td>\n",
        "      <td>3.491973e+01</td>\n",
        "      <td>-6.682480</td>\n",
@@ -1057,19 +1141,17 @@
        "    <tr>\n",
        "      <th>min</th>\n",
        "      <td>2.020121e+07</td>\n",
-       "      <td>2.020121e+07</td>\n",
+       "      <td>2.020122e+07</td>\n",
        "      <td>5.919818e+04</td>\n",
-       "      <td>5.919820e+04</td>\n",
        "      <td>5.919820e+04</td>\n",
        "      <td>5.919822e+04</td>\n",
        "      <td>0.040346</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25%</th>\n",
-       "      <td>2.021032e+07</td>\n",
+       "      <td>2.021031e+07</td>\n",
        "      <td>2.021033e+07</td>\n",
        "      <td>5.928912e+04</td>\n",
-       "      <td>5.929416e+04</td>\n",
        "      <td>5.929314e+04</td>\n",
        "      <td>5.930534e+04</td>\n",
        "      <td>16.223611</td>\n",
@@ -1079,7 +1161,6 @@
        "      <td>2.021041e+07</td>\n",
        "      <td>2.021041e+07</td>\n",
        "      <td>5.931522e+04</td>\n",
-       "      <td>5.931732e+04</td>\n",
        "      <td>5.931727e+04</td>\n",
        "      <td>5.931835e+04</td>\n",
        "      <td>3.132923</td>\n",
@@ -1089,7 +1170,6 @@
        "      <td>2.021042e+07</td>\n",
        "      <td>2.021050e+07</td>\n",
        "      <td>5.933013e+04</td>\n",
-       "      <td>5.933339e+04</td>\n",
        "      <td>5.933368e+04</td>\n",
        "      <td>5.933830e+04</td>\n",
        "      <td>8.168697</td>\n",
@@ -1101,7 +1181,6 @@
        "      <td>5.937621e+04</td>\n",
        "      <td>5.937621e+04</td>\n",
        "      <td>5.937621e+04</td>\n",
-       "      <td>5.937621e+04</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1109,34 +1188,60 @@
        "</div>"
       ],
       "text/plain": [
-       "         FIRSTNIGHT     LASTNIGHT       MIN_MJD    CENTER_MJD      MEAN_MJD  \\\n",
+       "         FIRSTNIGHT     LASTNIGHT       MIN_MJD      MEAN_MJD       MAX_MJD  \\\n",
        "count  2.451325e+06  2.451325e+06  2.451325e+06  2.451325e+06  2.451325e+06   \n",
-       "mean   2.021002e+07  2.021015e+07  5.930167e+04  5.930696e+04  5.930609e+04   \n",
-       "std    1.757134e+03  1.495939e+03  4.160221e+01  3.726858e+01  3.846983e+01   \n",
-       "min    2.020121e+07  2.020121e+07  5.919818e+04  5.919820e+04  5.919820e+04   \n",
-       "25%    2.021032e+07  2.021033e+07  5.928912e+04  5.929416e+04  5.929314e+04   \n",
-       "50%    2.021041e+07  2.021041e+07  5.931522e+04  5.931732e+04  5.931727e+04   \n",
-       "75%    2.021042e+07  2.021050e+07  5.933013e+04  5.933339e+04  5.933368e+04   \n",
+       "mean   2.021002e+07  2.021016e+07  5.930167e+04  5.930609e+04  5.931224e+04   \n",
+       "std    1.761005e+03  1.491326e+03  4.160221e+01  3.846983e+01  3.491973e+01   \n",
+       "min    2.020121e+07  2.020122e+07  5.919818e+04  5.919820e+04  5.919822e+04   \n",
+       "25%    2.021031e+07  2.021033e+07  5.928912e+04  5.929314e+04  5.930534e+04   \n",
+       "50%    2.021041e+07  2.021041e+07  5.931522e+04  5.931727e+04  5.931835e+04   \n",
+       "75%    2.021042e+07  2.021050e+07  5.933013e+04  5.933368e+04  5.933830e+04   \n",
        "max    2.021061e+07  2.021061e+07  5.937621e+04  5.937621e+04  5.937621e+04   \n",
        "\n",
-       "            MAX_MJD  MAX_MIN_DIFF  \n",
-       "count  2.451325e+06      0.000000  \n",
-       "mean   5.931224e+04     10.565186  \n",
-       "std    3.491973e+01     -6.682480  \n",
-       "min    5.919822e+04      0.040346  \n",
-       "25%    5.930534e+04     16.223611  \n",
-       "50%    5.931835e+04      3.132923  \n",
-       "75%    5.933830e+04      8.168697  \n",
-       "max    5.937621e+04      0.000000  "
+       "       MAX_MIN_DIFF  \n",
+       "count      0.000000  \n",
+       "mean      10.565186  \n",
+       "std       -6.682480  \n",
+       "min        0.040346  \n",
+       "25%       16.223611  \n",
+       "50%        3.132923  \n",
+       "75%        8.168697  \n",
+       "max        0.000000  "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93f82ed0-6641-47ec-86bd-7e56cce7a345",
+   "metadata": {},
+   "source": [
+    "## Check on edge case tile\n",
+    "\n",
+    "Tile 80870 is duplicated and includes two values of `LASTNIGHT = [20210512, 20210513]` rather than a single one. Check that both entries still exist, implying that there will be N=10,000 rows instead of 5,000 rows for a normal single tile."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "5c7778cc-b08d-4666-ad53-e7657ed9f8a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if zcat_type=='cumulative':\n",
+    "    tiledup = 80870\n",
+    "    \n",
+    "    istile = tz['TILEID']==tiledup\n",
+    "    \n",
+    "    print(len(tz[istile]))\n",
+    "    print(np.unique(tz['LASTNIGHT'][istile]))"
    ]
   },
   {
@@ -1149,7 +1254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 38,
    "id": "b156c497-5b64-4817-83b8-c3e48938b130",
    "metadata": {},
    "outputs": [
@@ -1184,7 +1289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 39,
    "id": "6864858a-6250-42d0-bbd1-8e66c3796206",
    "metadata": {},
    "outputs": [
@@ -1192,29 +1297,29 @@
      "data": {
       "text/html": [
        "<div><i>Table length=5</i>\n",
-       "<table id=\"table139852054681200\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>TARGETID</th><th>SURVEY</th><th>PROGRAM</th><th>HEALPIX</th><th>SPGRPVAL</th><th>Z</th><th>ZERR</th><th>ZWARN</th><th>CHI2</th><th>COEFF [10]</th><th>NPIXELS</th><th>SPECTYPE</th><th>SUBTYPE</th><th>NCOEFF</th><th>DELTACHI2</th><th>COADD_FIBERSTATUS</th><th>TARGET_RA</th><th>TARGET_DEC</th><th>PMRA</th><th>PMDEC</th><th>REF_EPOCH</th><th>FA_TARGET</th><th>FA_TYPE</th><th>OBJTYPE</th><th>SUBPRIORITY</th><th>OBSCONDITIONS</th><th>RELEASE</th><th>BRICKNAME</th><th>BRICKID</th><th>BRICK_OBJID</th><th>MORPHTYPE</th><th>EBV</th><th>FLUX_G</th><th>FLUX_R</th><th>FLUX_Z</th><th>FLUX_W1</th><th>FLUX_W2</th><th>FLUX_IVAR_G</th><th>FLUX_IVAR_R</th><th>FLUX_IVAR_Z</th><th>FLUX_IVAR_W1</th><th>FLUX_IVAR_W2</th><th>FIBERFLUX_G</th><th>FIBERFLUX_R</th><th>FIBERFLUX_Z</th><th>FIBERTOTFLUX_G</th><th>FIBERTOTFLUX_R</th><th>FIBERTOTFLUX_Z</th><th>MASKBITS</th><th>SERSIC</th><th>SHAPE_R</th><th>SHAPE_E1</th><th>SHAPE_E2</th><th>REF_ID</th><th>REF_CAT</th><th>GAIA_PHOT_G_MEAN_MAG</th><th>GAIA_PHOT_BP_MEAN_MAG</th><th>GAIA_PHOT_RP_MEAN_MAG</th><th>PARALLAX</th><th>PHOTSYS</th><th>PRIORITY_INIT</th><th>NUMOBS_INIT</th><th>CMX_TARGET</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>SCND_TARGET</th><th>SV1_DESI_TARGET</th><th>SV1_BGS_TARGET</th><th>SV1_MWS_TARGET</th><th>SV1_SCND_TARGET</th><th>SV2_DESI_TARGET</th><th>SV2_BGS_TARGET</th><th>SV2_MWS_TARGET</th><th>SV2_SCND_TARGET</th><th>SV3_DESI_TARGET</th><th>SV3_BGS_TARGET</th><th>SV3_MWS_TARGET</th><th>SV3_SCND_TARGET</th><th>PLATE_RA</th><th>PLATE_DEC</th><th>COADD_NUMEXP</th><th>COADD_EXPTIME</th><th>COADD_NUMNIGHT</th><th>COADD_NUMTILE</th><th>MEAN_DELTA_X</th><th>RMS_DELTA_X</th><th>MEAN_DELTA_Y</th><th>RMS_DELTA_Y</th><th>MEAN_FIBER_RA</th><th>STD_FIBER_RA</th><th>MEAN_FIBER_DEC</th><th>STD_FIBER_DEC</th><th>MEAN_PSF_TO_FIBER_SPECFLUX</th><th>TSNR2_GPBDARK_B</th><th>TSNR2_ELG_B</th><th>TSNR2_GPBBRIGHT_B</th><th>TSNR2_LYA_B</th><th>TSNR2_BGS_B</th><th>TSNR2_GPBBACKUP_B</th><th>TSNR2_QSO_B</th><th>TSNR2_LRG_B</th><th>TSNR2_GPBDARK_R</th><th>TSNR2_ELG_R</th><th>TSNR2_GPBBRIGHT_R</th><th>TSNR2_LYA_R</th><th>TSNR2_BGS_R</th><th>TSNR2_GPBBACKUP_R</th><th>TSNR2_QSO_R</th><th>TSNR2_LRG_R</th><th>TSNR2_GPBDARK_Z</th><th>TSNR2_ELG_Z</th><th>TSNR2_GPBBRIGHT_Z</th><th>TSNR2_LYA_Z</th><th>TSNR2_BGS_Z</th><th>TSNR2_GPBBACKUP_Z</th><th>TSNR2_QSO_Z</th><th>TSNR2_LRG_Z</th><th>TSNR2_GPBDARK</th><th>TSNR2_ELG</th><th>TSNR2_GPBBRIGHT</th><th>TSNR2_LYA</th><th>TSNR2_BGS</th><th>TSNR2_GPBBACKUP</th><th>TSNR2_QSO</th><th>TSNR2_LRG</th><th>SV_NSPEC</th><th>SV_PRIMARY</th><th>ZCAT_NSPEC</th><th>ZCAT_PRIMARY</th><th>FIRSTNIGHT</th><th>LASTNIGHT</th><th>MIN_MJD</th><th>CENTER_MJD</th><th>MEAN_MJD</th><th>MAX_MJD</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>bytes7</th><th>bytes6</th><th>int32</th><th>int32</th><th>float64</th><th>float64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>bytes6</th><th>bytes20</th><th>int64</th><th>float64</th><th>int32</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th><th>int64</th><th>uint8</th><th>bytes3</th><th>float64</th><th>int32</th><th>int16</th><th>bytes8</th><th>int32</th><th>int32</th><th>bytes4</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int16</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int64</th><th>bytes2</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>bytes1</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int16</th><th>float32</th><th>int16</th><th>int16</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th><th>float32</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int32</th><th>bool</th><th>int64</th><th>bool</th><th>int32</th><th>int32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>39628473198708395</td><td>cmx</td><td>other</td><td>2154</td><td>2154</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>23.661967677367254</td><td>29.84758879289675</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>9007199254742016</td><td>1</td><td>TGT</td><td>0.3743222091683128</td><td>7</td><td>9010</td><td>N/A</td><td>494512</td><td>1707</td><td>DEV</td><td>0.056008916</td><td>0.8742358</td><td>4.4879527</td><td>14.53286</td><td>40.183647</td><td>23.470558</td><td>846.09424</td><td>161.24467</td><td>27.071745</td><td>-1.0</td><td>-1.0</td><td>0.30432662</td><td>1.5622828</td><td>5.0589743</td><td>0.30432662</td><td>1.5622828</td><td>5.0589743</td><td>0</td><td>4.0</td><td>1.4857041</td><td>-0.47312373</td><td>0.34610084</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3200</td><td>1</td><td>9007199254742016</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>23.661967677367254</td><td>29.84758879289675</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>23.6619676773673</td><td>0.0</td><td>29.8475887928968</td><td>0.0</td><td>0.7702122</td><td>334.5758</td><td>0.23833227</td><td>63.154266</td><td>251.84634</td><td>1200.8414</td><td>489.7509</td><td>6.6365247</td><td>1.7938427</td><td>29931.836</td><td>67.48044</td><td>5253.2964</td><td>0.107736714</td><td>5998.398</td><td>33749.49</td><td>20.86845</td><td>95.85028</td><td>4.4280867e-05</td><td>226.88919</td><td>8.178434e-06</td><td>0.0</td><td>9751.99</td><td>5.995135e-05</td><td>48.05161</td><td>102.743744</td><td>30266.412</td><td>294.60797</td><td>5316.4507</td><td>251.95409</td><td>16951.23</td><td>34239.24</td><td>75.55658</td><td>200.38788</td><td>0</td><td>False</td><td>1</td><td>True</td><td>20201216</td><td>20201216</td><td>59200.06640136</td><td>59200.095106365</td><td>59200.095110124996</td><td>59200.12381137</td></tr>\n",
-       "<tr><td>39628473198711342</td><td>cmx</td><td>other</td><td>2152</td><td>2152</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>23.80220668826011</td><td>29.832150182607567</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>1280</td><td>1</td><td>TGT</td><td>0.7489200605083568</td><td>5</td><td>9010</td><td>N/A</td><td>494512</td><td>4654</td><td>DEV</td><td>0.053667612</td><td>2.6539938</td><td>11.6347475</td><td>23.4123</td><td>50.11407</td><td>35.76747</td><td>595.7886</td><td>118.594986</td><td>25.252254</td><td>-1.0</td><td>-1.0</td><td>1.2104546</td><td>5.3064675</td><td>10.678067</td><td>1.2104546</td><td>5.3064675</td><td>10.678067</td><td>0</td><td>4.0</td><td>0.6114804</td><td>-0.016180348</td><td>-0.099382535</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3200</td><td>1</td><td>1280</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>23.80220668826011</td><td>29.832150182607567</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>23.8022066882601</td><td>0.0</td><td>29.832150182607588</td><td>0.0</td><td>0.7802256</td><td>336.3489</td><td>0.24101405</td><td>63.501137</td><td>254.75517</td><td>1214.5858</td><td>492.71896</td><td>6.7145753</td><td>1.8078632</td><td>30322.682</td><td>68.46811</td><td>5322.6733</td><td>0.10913243</td><td>6050.4844</td><td>34205.188</td><td>21.129179</td><td>97.14442</td><td>4.468534e-05</td><td>229.07835</td><td>8.253198e-06</td><td>0.0</td><td>9876.345</td><td>6.0501185e-05</td><td>48.593376</td><td>103.95344</td><td>30659.031</td><td>297.78748</td><td>5386.1743</td><td>254.8643</td><td>17141.414</td><td>34697.906</td><td>76.43713</td><td>202.90572</td><td>0</td><td>False</td><td>1</td><td>True</td><td>20201216</td><td>20201216</td><td>59200.06640136</td><td>59200.095106365</td><td>59200.095110125</td><td>59200.12381137</td></tr>\n",
-       "<tr><td>39628473202903539</td><td>cmx</td><td>other</td><td>2152</td><td>2152</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>23.9976460870853</td><td>29.8298292545281</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>4096</td><td>1</td><td>TGT</td><td>0.07391118716059553</td><td>1</td><td>9010</td><td>N/A</td><td>494513</td><td>2547</td><td>PSF</td><td>0.04923722</td><td>0.36979324</td><td>0.9976344</td><td>1.748319</td><td>2.46375</td><td>3.3211248</td><td>1973.6221</td><td>577.8516</td><td>77.217896</td><td>-1.0</td><td>-1.0</td><td>0.28765</td><td>0.776027</td><td>1.3599598</td><td>0.28765</td><td>0.776027</td><td>1.3599598</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3400</td><td>1</td><td>4096</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>23.9976460870853</td><td>29.8298292545281</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>23.9976460870853</td><td>0.0</td><td>29.8298292545281</td><td>0.0</td><td>0.789</td><td>354.91718</td><td>0.2617178</td><td>66.83243</td><td>279.138</td><td>1302.0255</td><td>514.57477</td><td>7.2949877</td><td>1.9679965</td><td>32698.225</td><td>72.3826</td><td>5724.0327</td><td>0.12486173</td><td>6486.4995</td><td>36558.098</td><td>22.485813</td><td>103.08629</td><td>5.2723684e-05</td><td>243.56364</td><td>9.7335205e-06</td><td>0.0</td><td>10398.31</td><td>7.1218026e-05</td><td>51.462486</td><td>110.08269</td><td>33053.14</td><td>316.20795</td><td>5790.865</td><td>279.26285</td><td>18186.834</td><td>37072.67</td><td>81.243286</td><td>215.13696</td><td>0</td><td>False</td><td>1</td><td>True</td><td>20201216</td><td>20201216</td><td>59200.06640136</td><td>59200.095106365</td><td>59200.095110124996</td><td>59200.12381137</td></tr>\n",
-       "<tr><td>39628473207095521</td><td>cmx</td><td>other</td><td>2153</td><td>2153</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>24.163411373260953</td><td>29.79216658799389</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>2048</td><td>1</td><td>TGT</td><td>0.555666204166491</td><td>3</td><td>9010</td><td>N/A</td><td>494514</td><td>225</td><td>PSF</td><td>0.045480132</td><td>0.30380702</td><td>0.3845816</td><td>1.4267591</td><td>8.489307</td><td>7.9283123</td><td>1792.5405</td><td>496.92365</td><td>77.64431</td><td>-1.0</td><td>-1.0</td><td>0.23662426</td><td>0.29953662</td><td>1.1112508</td><td>0.23662426</td><td>0.29953662</td><td>1.1112508</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3000</td><td>1</td><td>2048</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>24.163411373260953</td><td>29.79216658799389</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>24.163411373261</td><td>0.0</td><td>29.792166587993894</td><td>0.0</td><td>0.789</td><td>337.05124</td><td>0.2431455</td><td>63.58909</td><td>253.58008</td><td>1227.6969</td><td>492.40305</td><td>6.760502</td><td>1.8641728</td><td>31537.506</td><td>69.669136</td><td>5534.6167</td><td>0.12165418</td><td>6253.054</td><td>35545.855</td><td>21.641685</td><td>99.22704</td><td>5.071971e-05</td><td>230.93983</td><td>9.3810295e-06</td><td>0.0</td><td>9997.022</td><td>6.897441e-05</td><td>49.029175</td><td>104.93886</td><td>31874.557</td><td>300.8521</td><td>5598.2056</td><td>253.70174</td><td>17477.773</td><td>36038.258</td><td>77.431366</td><td>206.03008</td><td>0</td><td>False</td><td>1</td><td>True</td><td>20201216</td><td>20201216</td><td>59200.06640136</td><td>59200.095106365</td><td>59200.095110125</td><td>59200.12381137</td></tr>\n",
-       "<tr><td>39628478437397782</td><td>cmx</td><td>other</td><td>2154</td><td>2154</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>23.004779136437485</td><td>30.119407147896</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>2048</td><td>1</td><td>TGT</td><td>0.8550797457575564</td><td>3</td><td>9010</td><td>N/A</td><td>495761</td><td>5398</td><td>DEV</td><td>0.06340205</td><td>0.66084456</td><td>1.152647</td><td>3.5934534</td><td>9.887055</td><td>9.529856</td><td>921.0356</td><td>261.8495</td><td>31.15059</td><td>-1.0</td><td>-1.0</td><td>0.24227671</td><td>0.42257974</td><td>1.3174204</td><td>0.24281985</td><td>0.45946148</td><td>1.447525</td><td>0</td><td>4.0</td><td>1.2109119</td><td>0.2759375</td><td>-0.31842917</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3000</td><td>1</td><td>2048</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>23.004779136437485</td><td>30.119407147896</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>23.0047791364375</td><td>0.0</td><td>30.119407147896005</td><td>0.0</td><td>0.77242905</td><td>657.1011</td><td>0.2452533</td><td>121.30457</td><td>132.81993</td><td>1427.7833</td><td>882.08527</td><td>6.589169</td><td>2.9969666</td><td>31845.826</td><td>75.80818</td><td>5568.016</td><td>0.09411048</td><td>6172.1987</td><td>35468.086</td><td>22.631115</td><td>105.63433</td><td>5.724519e-05</td><td>226.35516</td><td>1.0555282e-05</td><td>0.0</td><td>10588.217</td><td>7.692063e-05</td><td>49.46934</td><td>107.10196</td><td>32502.928</td><td>302.4086</td><td>5689.321</td><td>132.91405</td><td>18188.2</td><td>36350.17</td><td>78.68962</td><td>215.73325</td><td>0</td><td>False</td><td>1</td><td>True</td><td>20201216</td><td>20201216</td><td>59200.06640136</td><td>59200.095106365</td><td>59200.09511012501</td><td>59200.12381137</td></tr>\n",
+       "<table id=\"table140047162754960\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>TARGETID</th><th>SURVEY</th><th>PROGRAM</th><th>HEALPIX</th><th>SPGRPVAL</th><th>Z</th><th>ZERR</th><th>ZWARN</th><th>CHI2</th><th>COEFF</th><th>NPIXELS</th><th>SPECTYPE</th><th>SUBTYPE</th><th>NCOEFF</th><th>DELTACHI2</th><th>COADD_FIBERSTATUS</th><th>TARGET_RA</th><th>TARGET_DEC</th><th>PMRA</th><th>PMDEC</th><th>REF_EPOCH</th><th>FA_TARGET</th><th>FA_TYPE</th><th>OBJTYPE</th><th>SUBPRIORITY</th><th>OBSCONDITIONS</th><th>RELEASE</th><th>BRICKNAME</th><th>BRICKID</th><th>BRICK_OBJID</th><th>MORPHTYPE</th><th>EBV</th><th>FLUX_G</th><th>FLUX_R</th><th>FLUX_Z</th><th>FLUX_W1</th><th>FLUX_W2</th><th>FLUX_IVAR_G</th><th>FLUX_IVAR_R</th><th>FLUX_IVAR_Z</th><th>FLUX_IVAR_W1</th><th>FLUX_IVAR_W2</th><th>FIBERFLUX_G</th><th>FIBERFLUX_R</th><th>FIBERFLUX_Z</th><th>FIBERTOTFLUX_G</th><th>FIBERTOTFLUX_R</th><th>FIBERTOTFLUX_Z</th><th>MASKBITS</th><th>SERSIC</th><th>SHAPE_R</th><th>SHAPE_E1</th><th>SHAPE_E2</th><th>REF_ID</th><th>REF_CAT</th><th>GAIA_PHOT_G_MEAN_MAG</th><th>GAIA_PHOT_BP_MEAN_MAG</th><th>GAIA_PHOT_RP_MEAN_MAG</th><th>PARALLAX</th><th>PHOTSYS</th><th>PRIORITY_INIT</th><th>NUMOBS_INIT</th><th>CMX_TARGET</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>SCND_TARGET</th><th>SV1_DESI_TARGET</th><th>SV1_BGS_TARGET</th><th>SV1_MWS_TARGET</th><th>SV1_SCND_TARGET</th><th>SV2_DESI_TARGET</th><th>SV2_BGS_TARGET</th><th>SV2_MWS_TARGET</th><th>SV2_SCND_TARGET</th><th>SV3_DESI_TARGET</th><th>SV3_BGS_TARGET</th><th>SV3_MWS_TARGET</th><th>SV3_SCND_TARGET</th><th>PLATE_RA</th><th>PLATE_DEC</th><th>COADD_NUMEXP</th><th>COADD_EXPTIME</th><th>COADD_NUMNIGHT</th><th>COADD_NUMTILE</th><th>MEAN_DELTA_X</th><th>RMS_DELTA_X</th><th>MEAN_DELTA_Y</th><th>RMS_DELTA_Y</th><th>MEAN_FIBER_RA</th><th>STD_FIBER_RA</th><th>MEAN_FIBER_DEC</th><th>STD_FIBER_DEC</th><th>MEAN_PSF_TO_FIBER_SPECFLUX</th><th>TSNR2_GPBDARK_B</th><th>TSNR2_ELG_B</th><th>TSNR2_GPBBRIGHT_B</th><th>TSNR2_LYA_B</th><th>TSNR2_BGS_B</th><th>TSNR2_GPBBACKUP_B</th><th>TSNR2_QSO_B</th><th>TSNR2_LRG_B</th><th>TSNR2_GPBDARK_R</th><th>TSNR2_ELG_R</th><th>TSNR2_GPBBRIGHT_R</th><th>TSNR2_LYA_R</th><th>TSNR2_BGS_R</th><th>TSNR2_GPBBACKUP_R</th><th>TSNR2_QSO_R</th><th>TSNR2_LRG_R</th><th>TSNR2_GPBDARK_Z</th><th>TSNR2_ELG_Z</th><th>TSNR2_GPBBRIGHT_Z</th><th>TSNR2_LYA_Z</th><th>TSNR2_BGS_Z</th><th>TSNR2_GPBBACKUP_Z</th><th>TSNR2_QSO_Z</th><th>TSNR2_LRG_Z</th><th>TSNR2_GPBDARK</th><th>TSNR2_ELG</th><th>TSNR2_GPBBRIGHT</th><th>TSNR2_LYA</th><th>TSNR2_BGS</th><th>TSNR2_GPBBACKUP</th><th>TSNR2_QSO</th><th>TSNR2_LRG</th><th>SV_NSPEC</th><th>SV_PRIMARY</th><th>ZCAT_NSPEC</th><th>ZCAT_PRIMARY</th><th>MIN_MJD</th><th>MEAN_MJD</th><th>MAX_MJD</th><th>FIRSTNIGHT</th><th>LASTNIGHT</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>bytes7</th><th>bytes6</th><th>int32</th><th>int32</th><th>float64</th><th>float64</th><th>int64</th><th>float64</th><th>float64[10]</th><th>int64</th><th>bytes6</th><th>bytes20</th><th>int64</th><th>float64</th><th>int32</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th><th>int64</th><th>uint8</th><th>bytes3</th><th>float64</th><th>int32</th><th>int16</th><th>bytes8</th><th>int32</th><th>int32</th><th>bytes4</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int16</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int64</th><th>bytes2</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>bytes1</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int16</th><th>float32</th><th>int16</th><th>int16</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th><th>float32</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int32</th><th>bool</th><th>int64</th><th>bool</th><th>float64</th><th>float64</th><th>float64</th><th>int32</th><th>int32</th></tr></thead>\n",
+       "<tr><td>39628473198708395</td><td>cmx</td><td>other</td><td>2154</td><td>2154</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>23.661967677367254</td><td>29.84758879289675</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>9007199254742016</td><td>1</td><td>TGT</td><td>0.3743222091683128</td><td>7</td><td>9010</td><td>N/A</td><td>494512</td><td>1707</td><td>DEV</td><td>0.056008916</td><td>0.8742358</td><td>4.4879527</td><td>14.53286</td><td>40.183647</td><td>23.470558</td><td>846.09424</td><td>161.24467</td><td>27.071745</td><td>-1.0</td><td>-1.0</td><td>0.30432662</td><td>1.5622828</td><td>5.0589743</td><td>0.30432662</td><td>1.5622828</td><td>5.0589743</td><td>0</td><td>4.0</td><td>1.4857041</td><td>-0.47312373</td><td>0.34610084</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3200</td><td>1</td><td>9007199254742016</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>23.661967677367254</td><td>29.84758879289675</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>23.6619676773673</td><td>0.0</td><td>29.8475887928968</td><td>0.0</td><td>0.7702122</td><td>334.5758</td><td>0.23833227</td><td>63.154266</td><td>251.84634</td><td>1200.8414</td><td>489.7509</td><td>6.6365247</td><td>1.7938427</td><td>29931.836</td><td>67.48044</td><td>5253.2964</td><td>0.107736714</td><td>5998.398</td><td>33749.49</td><td>20.86845</td><td>95.85028</td><td>4.4280867e-05</td><td>226.88919</td><td>8.178434e-06</td><td>0.0</td><td>9751.99</td><td>5.995135e-05</td><td>48.05161</td><td>102.743744</td><td>30266.412</td><td>294.60797</td><td>5316.4507</td><td>251.95409</td><td>16951.23</td><td>34239.24</td><td>75.55658</td><td>200.38788</td><td>0</td><td>False</td><td>1</td><td>True</td><td>59200.06640136</td><td>59200.095110124996</td><td>59200.12381137</td><td>20201216</td><td>20201216</td></tr>\n",
+       "<tr><td>39628473198711342</td><td>cmx</td><td>other</td><td>2152</td><td>2152</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>23.80220668826011</td><td>29.832150182607567</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>1280</td><td>1</td><td>TGT</td><td>0.7489200605083568</td><td>5</td><td>9010</td><td>N/A</td><td>494512</td><td>4654</td><td>DEV</td><td>0.053667612</td><td>2.6539938</td><td>11.6347475</td><td>23.4123</td><td>50.11407</td><td>35.76747</td><td>595.7886</td><td>118.594986</td><td>25.252254</td><td>-1.0</td><td>-1.0</td><td>1.2104546</td><td>5.3064675</td><td>10.678067</td><td>1.2104546</td><td>5.3064675</td><td>10.678067</td><td>0</td><td>4.0</td><td>0.6114804</td><td>-0.016180348</td><td>-0.099382535</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3200</td><td>1</td><td>1280</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>23.80220668826011</td><td>29.832150182607567</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>23.8022066882601</td><td>0.0</td><td>29.832150182607588</td><td>0.0</td><td>0.7802256</td><td>336.3489</td><td>0.24101405</td><td>63.501137</td><td>254.75517</td><td>1214.5858</td><td>492.71896</td><td>6.7145753</td><td>1.8078632</td><td>30322.682</td><td>68.46811</td><td>5322.6733</td><td>0.10913243</td><td>6050.4844</td><td>34205.188</td><td>21.129179</td><td>97.14442</td><td>4.468534e-05</td><td>229.07835</td><td>8.253198e-06</td><td>0.0</td><td>9876.345</td><td>6.0501185e-05</td><td>48.593376</td><td>103.95344</td><td>30659.031</td><td>297.78748</td><td>5386.1743</td><td>254.8643</td><td>17141.414</td><td>34697.906</td><td>76.43713</td><td>202.90572</td><td>0</td><td>False</td><td>1</td><td>True</td><td>59200.06640136</td><td>59200.095110124996</td><td>59200.12381137</td><td>20201216</td><td>20201216</td></tr>\n",
+       "<tr><td>39628473202903539</td><td>cmx</td><td>other</td><td>2152</td><td>2152</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>23.9976460870853</td><td>29.8298292545281</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>4096</td><td>1</td><td>TGT</td><td>0.07391118716059553</td><td>1</td><td>9010</td><td>N/A</td><td>494513</td><td>2547</td><td>PSF</td><td>0.04923722</td><td>0.36979324</td><td>0.9976344</td><td>1.748319</td><td>2.46375</td><td>3.3211248</td><td>1973.6221</td><td>577.8516</td><td>77.217896</td><td>-1.0</td><td>-1.0</td><td>0.28765</td><td>0.776027</td><td>1.3599598</td><td>0.28765</td><td>0.776027</td><td>1.3599598</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3400</td><td>1</td><td>4096</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>23.9976460870853</td><td>29.8298292545281</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>23.9976460870853</td><td>0.0</td><td>29.8298292545281</td><td>0.0</td><td>0.789</td><td>354.91718</td><td>0.2617178</td><td>66.83243</td><td>279.138</td><td>1302.0255</td><td>514.57477</td><td>7.2949877</td><td>1.9679965</td><td>32698.225</td><td>72.3826</td><td>5724.0327</td><td>0.12486173</td><td>6486.4995</td><td>36558.098</td><td>22.485813</td><td>103.08629</td><td>5.2723684e-05</td><td>243.56364</td><td>9.7335205e-06</td><td>0.0</td><td>10398.31</td><td>7.1218026e-05</td><td>51.462486</td><td>110.08269</td><td>33053.14</td><td>316.20795</td><td>5790.865</td><td>279.26285</td><td>18186.834</td><td>37072.67</td><td>81.243286</td><td>215.13696</td><td>0</td><td>False</td><td>1</td><td>True</td><td>59200.06640136</td><td>59200.095110124996</td><td>59200.12381137</td><td>20201216</td><td>20201216</td></tr>\n",
+       "<tr><td>39628473207095521</td><td>cmx</td><td>other</td><td>2153</td><td>2153</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>24.163411373260953</td><td>29.79216658799389</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>2048</td><td>1</td><td>TGT</td><td>0.555666204166491</td><td>3</td><td>9010</td><td>N/A</td><td>494514</td><td>225</td><td>PSF</td><td>0.045480132</td><td>0.30380702</td><td>0.3845816</td><td>1.4267591</td><td>8.489307</td><td>7.9283123</td><td>1792.5405</td><td>496.92365</td><td>77.64431</td><td>-1.0</td><td>-1.0</td><td>0.23662426</td><td>0.29953662</td><td>1.1112508</td><td>0.23662426</td><td>0.29953662</td><td>1.1112508</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3000</td><td>1</td><td>2048</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>24.163411373260953</td><td>29.79216658799389</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>24.163411373261</td><td>0.0</td><td>29.792166587993894</td><td>0.0</td><td>0.789</td><td>337.05124</td><td>0.2431455</td><td>63.58909</td><td>253.58008</td><td>1227.6969</td><td>492.40305</td><td>6.760502</td><td>1.8641728</td><td>31537.506</td><td>69.669136</td><td>5534.6167</td><td>0.12165418</td><td>6253.054</td><td>35545.855</td><td>21.641685</td><td>99.22704</td><td>5.071971e-05</td><td>230.93983</td><td>9.3810295e-06</td><td>0.0</td><td>9997.022</td><td>6.897441e-05</td><td>49.029175</td><td>104.93886</td><td>31874.557</td><td>300.8521</td><td>5598.2056</td><td>253.70174</td><td>17477.773</td><td>36038.258</td><td>77.431366</td><td>206.03008</td><td>0</td><td>False</td><td>1</td><td>True</td><td>59200.06640136</td><td>59200.095110124996</td><td>59200.12381137</td><td>20201216</td><td>20201216</td></tr>\n",
+       "<tr><td>39628478437397782</td><td>cmx</td><td>other</td><td>2154</td><td>2154</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>512</td><td>23.004779136437485</td><td>30.119407147896</td><td>0.0</td><td>0.0</td><td>2020.9597</td><td>2048</td><td>1</td><td>TGT</td><td>0.8550797457575564</td><td>3</td><td>9010</td><td>N/A</td><td>495761</td><td>5398</td><td>DEV</td><td>0.06340205</td><td>0.66084456</td><td>1.152647</td><td>3.5934534</td><td>9.887055</td><td>9.529856</td><td>921.0356</td><td>261.8495</td><td>31.15059</td><td>-1.0</td><td>-1.0</td><td>0.24227671</td><td>0.42257974</td><td>1.3174204</td><td>0.24281985</td><td>0.45946148</td><td>1.447525</td><td>0</td><td>4.0</td><td>1.2109119</td><td>0.2759375</td><td>-0.31842917</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>3000</td><td>1</td><td>2048</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>23.004779136437485</td><td>30.119407147896</td><td>0</td><td>0.0</td><td>0</td><td>0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>23.0047791364375</td><td>0.0</td><td>30.119407147896005</td><td>0.0</td><td>0.77242905</td><td>657.1011</td><td>0.2452533</td><td>121.30457</td><td>132.81993</td><td>1427.7833</td><td>882.08527</td><td>6.589169</td><td>2.9969666</td><td>31845.826</td><td>75.80818</td><td>5568.016</td><td>0.09411048</td><td>6172.1987</td><td>35468.086</td><td>22.631115</td><td>105.63433</td><td>5.724519e-05</td><td>226.35516</td><td>1.0555282e-05</td><td>0.0</td><td>10588.217</td><td>7.692063e-05</td><td>49.46934</td><td>107.10196</td><td>32502.928</td><td>302.4086</td><td>5689.321</td><td>132.91405</td><td>18188.2</td><td>36350.17</td><td>78.68962</td><td>215.73325</td><td>0</td><td>False</td><td>1</td><td>True</td><td>59200.06640136</td><td>59200.095110124996</td><td>59200.12381137</td><td>20201216</td><td>20201216</td></tr>\n",
        "</table></div>"
       ],
       "text/plain": [
        "<Table length=5>\n",
-       "     TARGETID     SURVEY PROGRAM ...      MEAN_MJD         MAX_MJD    \n",
-       "      int64       bytes7  bytes6 ...      float64          float64    \n",
-       "----------------- ------ ------- ... ------------------ --------------\n",
-       "39628473198708395    cmx   other ... 59200.095110124996 59200.12381137\n",
-       "39628473198711342    cmx   other ...    59200.095110125 59200.12381137\n",
-       "39628473202903539    cmx   other ... 59200.095110124996 59200.12381137\n",
-       "39628473207095521    cmx   other ...    59200.095110125 59200.12381137\n",
-       "39628478437397782    cmx   other ...  59200.09511012501 59200.12381137"
+       "     TARGETID     SURVEY PROGRAM HEALPIX ...    MAX_MJD     FIRSTNIGHT LASTNIGHT\n",
+       "      int64       bytes7  bytes6  int32  ...    float64       int32      int32  \n",
+       "----------------- ------ ------- ------- ... -------------- ---------- ---------\n",
+       "39628473198708395    cmx   other    2154 ... 59200.12381137   20201216  20201216\n",
+       "39628473198711342    cmx   other    2152 ... 59200.12381137   20201216  20201216\n",
+       "39628473202903539    cmx   other    2152 ... 59200.12381137   20201216  20201216\n",
+       "39628473207095521    cmx   other    2153 ... 59200.12381137   20201216  20201216\n",
+       "39628478437397782    cmx   other    2154 ... 59200.12381137   20201216  20201216"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1225,78 +1330,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62aa8157-786d-4ae2-a51e-72ca0681fd75",
-   "metadata": {},
-   "source": [
-    "## Special edge case"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "5775bc68-8ee1-4113-b01c-70a6b577295c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test_id = 39627731599624825"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "edcacff3-833b-4518-9426-57b3c2523e6e",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=1</i>\n",
-       "<table id=\"table139682457869856\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>TARGETID</th><th>SURVEY</th><th>PROGRAM</th><th>HEALPIX</th><th>SPGRPVAL</th><th>Z</th><th>ZERR</th><th>ZWARN</th><th>CHI2</th><th>COEFF [10]</th><th>NPIXELS</th><th>SPECTYPE</th><th>SUBTYPE</th><th>NCOEFF</th><th>DELTACHI2</th><th>COADD_FIBERSTATUS</th><th>TARGET_RA</th><th>TARGET_DEC</th><th>PMRA</th><th>PMDEC</th><th>REF_EPOCH</th><th>FA_TARGET</th><th>FA_TYPE</th><th>OBJTYPE</th><th>SUBPRIORITY</th><th>OBSCONDITIONS</th><th>RELEASE</th><th>BRICKNAME</th><th>BRICKID</th><th>BRICK_OBJID</th><th>MORPHTYPE</th><th>EBV</th><th>FLUX_G</th><th>FLUX_R</th><th>FLUX_Z</th><th>FLUX_W1</th><th>FLUX_W2</th><th>FLUX_IVAR_G</th><th>FLUX_IVAR_R</th><th>FLUX_IVAR_Z</th><th>FLUX_IVAR_W1</th><th>FLUX_IVAR_W2</th><th>FIBERFLUX_G</th><th>FIBERFLUX_R</th><th>FIBERFLUX_Z</th><th>FIBERTOTFLUX_G</th><th>FIBERTOTFLUX_R</th><th>FIBERTOTFLUX_Z</th><th>MASKBITS</th><th>SERSIC</th><th>SHAPE_R</th><th>SHAPE_E1</th><th>SHAPE_E2</th><th>REF_ID</th><th>REF_CAT</th><th>GAIA_PHOT_G_MEAN_MAG</th><th>GAIA_PHOT_BP_MEAN_MAG</th><th>GAIA_PHOT_RP_MEAN_MAG</th><th>PARALLAX</th><th>PHOTSYS</th><th>PRIORITY_INIT</th><th>NUMOBS_INIT</th><th>CMX_TARGET</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>SCND_TARGET</th><th>SV1_DESI_TARGET</th><th>SV1_BGS_TARGET</th><th>SV1_MWS_TARGET</th><th>SV1_SCND_TARGET</th><th>SV2_DESI_TARGET</th><th>SV2_BGS_TARGET</th><th>SV2_MWS_TARGET</th><th>SV2_SCND_TARGET</th><th>SV3_DESI_TARGET</th><th>SV3_BGS_TARGET</th><th>SV3_MWS_TARGET</th><th>SV3_SCND_TARGET</th><th>PLATE_RA</th><th>PLATE_DEC</th><th>COADD_NUMEXP</th><th>COADD_EXPTIME</th><th>COADD_NUMNIGHT</th><th>COADD_NUMTILE</th><th>MEAN_DELTA_X</th><th>RMS_DELTA_X</th><th>MEAN_DELTA_Y</th><th>RMS_DELTA_Y</th><th>MEAN_FIBER_RA</th><th>STD_FIBER_RA</th><th>MEAN_FIBER_DEC</th><th>STD_FIBER_DEC</th><th>MEAN_PSF_TO_FIBER_SPECFLUX</th><th>TSNR2_GPBDARK_B</th><th>TSNR2_ELG_B</th><th>TSNR2_GPBBRIGHT_B</th><th>TSNR2_LYA_B</th><th>TSNR2_BGS_B</th><th>TSNR2_GPBBACKUP_B</th><th>TSNR2_QSO_B</th><th>TSNR2_LRG_B</th><th>TSNR2_GPBDARK_R</th><th>TSNR2_ELG_R</th><th>TSNR2_GPBBRIGHT_R</th><th>TSNR2_LYA_R</th><th>TSNR2_BGS_R</th><th>TSNR2_GPBBACKUP_R</th><th>TSNR2_QSO_R</th><th>TSNR2_LRG_R</th><th>TSNR2_GPBDARK_Z</th><th>TSNR2_ELG_Z</th><th>TSNR2_GPBBRIGHT_Z</th><th>TSNR2_LYA_Z</th><th>TSNR2_BGS_Z</th><th>TSNR2_GPBBACKUP_Z</th><th>TSNR2_QSO_Z</th><th>TSNR2_LRG_Z</th><th>TSNR2_GPBDARK</th><th>TSNR2_ELG</th><th>TSNR2_GPBBRIGHT</th><th>TSNR2_LYA</th><th>TSNR2_BGS</th><th>TSNR2_GPBBACKUP</th><th>TSNR2_QSO</th><th>TSNR2_LRG</th><th>SV_NSPEC</th><th>SV_PRIMARY</th><th>ZCAT_NSPEC</th><th>ZCAT_PRIMARY</th><th>FIRSTNIGHT</th><th>LASTNIGHT</th><th>MIN_MJD</th><th>CENTER_MJD</th><th>MEAN_MJD</th><th>MAX_MJD</th></tr></thead>\n",
-       "<thead><tr><th>int64</th><th>bytes7</th><th>bytes6</th><th>int32</th><th>int32</th><th>float64</th><th>float64</th><th>int64</th><th>float64</th><th>float64</th><th>int64</th><th>bytes6</th><th>bytes20</th><th>int64</th><th>float64</th><th>int32</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th><th>int64</th><th>uint8</th><th>bytes3</th><th>float64</th><th>int32</th><th>int16</th><th>bytes8</th><th>int32</th><th>int32</th><th>bytes4</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int16</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int64</th><th>bytes2</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>bytes1</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float64</th><th>float64</th><th>int16</th><th>float32</th><th>int16</th><th>int16</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th><th>float32</th><th>float64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>int32</th><th>bool</th><th>int64</th><th>bool</th><th>int32</th><th>int32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>39627731599624825</td><td>sv1</td><td>bright</td><td>22918</td><td>22918</td><td>-0.0019956912923479522</td><td>4.1311493573349107e-48</td><td>1570</td><td>8.999999999999996e+99</td><td>0.0 .. 0.0</td><td>0</td><td>STAR</td><td>CV</td><td>3</td><td>1.942668892225729e+84</td><td>0</td><td>73.34463034689205</td><td>-2.2622633392995275</td><td>0.0</td><td>0.0</td><td>2021.0034</td><td>1152921504606846976</td><td>1</td><td>TGT</td><td>0.8585540058266743</td><td>4</td><td>9010</td><td>0733m022</td><td>317701</td><td>2681</td><td>DEV</td><td>0.05414837</td><td>1.516642</td><td>7.0107694</td><td>16.5374</td><td>34.423656</td><td>21.993723</td><td>564.9237</td><td>160.30077</td><td>50.0471</td><td>2.43149</td><td>0.6469757</td><td>0.6426061</td><td>2.9704854</td><td>7.0069494</td><td>0.6426101</td><td>2.970508</td><td>7.007027</td><td>0</td><td>4.0</td><td>0.8341941</td><td>0.20632148</td><td>0.2062015</td><td>0</td><td>--</td><td>0.0</td><td>0.0</td><td>0.0</td><td>0.0</td><td>S</td><td>2000</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1152921504606846976</td><td>262148</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>73.34463034689205</td><td>-2.2622633392995275</td><td>1</td><td>300.0711</td><td>1</td><td>1</td><td>-0.08950243</td><td>0.08950243</td><td>-0.03618847</td><td>0.03618847</td><td>73.33626451245975</td><td>9.469096</td><td>-2.2596152724706733</td><td>2.9338548</td><td>0.27228257</td><td>40.814304</td><td>0.028947338</td><td>39.396584</td><td>9.633104</td><td>837.11676</td><td>36.088108</td><td>0.38779837</td><td>0.9504982</td><td>4649.0547</td><td>10.785365</td><td>4382.921</td><td>0.011474451</td><td>4832.835</td><td>3670.6765</td><td>1.5874908</td><td>45.59579</td><td>8.922884e-06</td><td>52.000984</td><td>8.507649e-06</td><td>0.0</td><td>11194.139</td><td>7.4439786e-06</td><td>5.315965</td><td>69.44099</td><td>4689.869</td><td>62.815296</td><td>4422.3174</td><td>9.644579</td><td>16864.09</td><td>3706.7646</td><td>7.291254</td><td>115.987274</td><td>1</td><td>True</td><td>1</td><td>True</td><td>20210224</td><td>20210224</td><td>59270.11094322</td><td>59270.11094322</td><td>59270.11094322</td><td>59270.11094322</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=1>\n",
-       "     TARGETID     SURVEY PROGRAM ...    MEAN_MJD       MAX_MJD    \n",
-       "      int64       bytes7  bytes6 ...    float64        float64    \n",
-       "----------------- ------ ------- ... -------------- --------------\n",
-       "39627731599624825    sv1  bright ... 59270.11094322 59270.11094322"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tz[tz['TARGETID']==test_id]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "05f368e0-55da-4075-bb3e-5f6cd4b80e51",
    "metadata": {},
    "source": [
-    "## Compare with targeting patch file (from database query)"
+    "## Compare with targeting patch file\n",
+    "\n",
+    "This is for rare edge cases with conflicting/missing info, including a few secondary targets and ToO (target of opportunity) observations. This patch file is provided along the VAC for information/completeness purposes but the corrections are *already applied*."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 40,
    "id": "db1041e9-2132-481e-9391-91daed2584a6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "patchfile = path_after+\"zall-pix-targeting-patch-edr.fits\"\n",
-    "tg = Table.read(patchfile)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "id": "5762ab03-57e0-4717-bb57-b21f619b5c46",
    "metadata": {},
    "outputs": [
     {
@@ -1308,13 +1353,14 @@
     }
    ],
    "source": [
-    "tg = tg[tg['SURVEY']!='cmx']  # N=272 excluding CMX\n",
+    "patchfile = vac_dir+\"zall-pix-targeting-patch-edr.fits\"\n",
+    "tg = Table.read(patchfile)\n",
     "print(f\"Check if N=272: {(len(tg)==272)}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 41,
    "id": "414dfca5-6f7a-46a0-bc9c-3dd294bab146",
    "metadata": {},
    "outputs": [
@@ -1322,10 +1368,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Filename: /global/cfs/cdirs/desi/science/gqp/vac/edr/zcat/v1.0/zall-pix-targeting-patch-edr.fits\n",
+      "Filename: ../../fuji/nersc/zall-pix-targeting-patch-edr.fits\n",
       "No.    Name      Ver    Type      Cards   Dimensions   Format\n",
       "  0  PRIMARY       1 PrimaryHDU       4   ()      \n",
-      "  1                1 BinTableHDU     48   457R x 20C   [K, 7A, 6A, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K]   \n"
+      "  1  TARGETPATCH    1 BinTableHDU     49   272R x 20C   [K, 7A, 6A, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K, K]   \n"
      ]
     }
    ],
@@ -1335,7 +1381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 42,
    "id": "913b765e-1744-4040-b28f-3b3a217ec7ec",
    "metadata": {},
    "outputs": [
@@ -1350,30 +1396,26 @@
     }
    ],
    "source": [
-    "surveys = np.unique(tg['SURVEY'])\n",
-    "for survey in surveys:\n",
+    "# Patch file is only used for zpix and not for ztile; this cell of for information (reporting how many row should have been patched)\n",
+    "# can uncomment to examine example rows or could add checks to compare values\n",
     "\n",
-    "    programs = np.unique(tg['PROGRAM'][tg['SURVEY']==survey])\n",
-    "    for program in programs:\n",
-    "        tg_sel = tg[(tg['SURVEY']==survey)&(tg['PROGRAM']==program)]\n",
-    "        tz_sel = tz[(tz['SURVEY']==survey)&(tz['PROGRAM']==program)]\n",
-    "        need_patch = np.isin(tz_sel['TARGETID'], tg_sel['TARGETID'])\n",
-    "        \n",
-    "        Npatch = len(tz_sel[need_patch])\n",
-    "        print(f\"In Survey={survey}; Program={program}; Nb that need targeting correction= {Npatch} [{np.round(Npatch/len(tz_sel)*100,3)}%]\")\n",
+    "if zcat_type=='healpix':\n",
+    "    surveys = np.unique(tg['SURVEY'])\n",
+    "    for survey in surveys:\n",
     "\n",
-    "        # Uncomment to print the first 10 results of the corrected table and patching table\n",
-    "#        print(tz_sel['TARGETID','SV1_DESI_TARGET','SV1_MWS_TARGET','SV3_DESI_TARGET'][need_patch][:10])\n",
-    "#        print(tg_sel['TARGETID','SV1_DESI_TARGET','SV1_MWS_TARGET','SV3_DESI_TARGET'][:10])"
+    "        programs = np.unique(tg['PROGRAM'][tg['SURVEY']==survey])\n",
+    "        for program in programs:\n",
+    "            tg_sel = tg[(tg['SURVEY']==survey)&(tg['PROGRAM']==program)]\n",
+    "            tz_sel = tz[(tz['SURVEY']==survey)&(tz['PROGRAM']==program)]\n",
+    "            need_patch = np.isin(tz_sel['TARGETID'], tg_sel['TARGETID'])\n",
+    "\n",
+    "            Npatch = len(tz_sel[need_patch])\n",
+    "            print(f\"In Survey={survey}; Program={program}; Nb that need targeting correction= {Npatch} [{np.round(Npatch/len(tz_sel)*100,3)}%]\")\n",
+    "\n",
+    "            # Uncomment to print the first 10 results of the corrected table and patching table\n",
+    "    #        print(tz_sel['TARGETID','SV1_DESI_TARGET','SV1_MWS_TARGET','SV3_DESI_TARGET'][need_patch][:10])\n",
+    "    #        print(tg_sel['TARGETID','SV1_DESI_TARGET','SV1_MWS_TARGET','SV3_DESI_TARGET'][:10])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2830a6f7-1754-4c59-b34a-7410bd1470ee",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Testing notebook can be run for either the ztile or zpix VAC and on either Data Lab or NERSC/Perlmutter.